### PR TITLE
Fixed Message unit tests and faster pic manager

### DIFF
--- a/CommunicationLibrary/Messages/SharedObjects/PictureManager.py
+++ b/CommunicationLibrary/Messages/SharedObjects/PictureManager.py
@@ -9,7 +9,7 @@ class PictureManager:
         shape = picture.shape
         rows = shape[0]
         cols = shape[1]
-        sizeOfParts = int(30000.0/(40*cols))
+        sizeOfParts = int(30000.0/(5*cols))
         numberOfParts = int(math.ceil(rows/sizeOfParts))
         splitFrames = np.array_split(picture, numberOfParts)
         return splitFrames, numberOfParts


### PR DESCRIPTION
Fixed unit tests for messages.  I realized there was a type error in my PIctureManager unit test so we were actually sending pic pieces of size 2000.  This should now be fixed to around 20,000 and the pic should appear within 4 seconds.